### PR TITLE
fix h1 font

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -14,7 +14,6 @@ code {
 
 h1 {
   color: azure;
-  font: bold 80%/1em Arial, Helvetica, sans-serif;
   background: #f1b308 url(./img/icon.png) no-repeat right top;
   background-size: 50px;
 }


### PR DESCRIPTION
cssが悪さしてるようなので、fontを消しました

oyukimaru.comのフォント消してみた
![image](https://user-images.githubusercontent.com/7395122/192137494-0a64bc63-ed41-4e22-994f-951c6c69730c.png)

oyukimaru.comではbackgroundも一緒に消えたけど、文字の大きさは変わった
![image](https://user-images.githubusercontent.com/7395122/192137501-f7d6bc7e-9084-44f3-851e-41f8273f6ecf.png)

localではbackgroudは問題なさそう
![image](https://user-images.githubusercontent.com/7395122/192137888-4df0bbf7-dacd-4c50-8d7c-149189f7d587.png)
